### PR TITLE
Hydrographic Core Messages

### DIFF
--- a/hydrographic_core_msgs/CMakeLists.txt
+++ b/hydrographic_core_msgs/CMakeLists.txt
@@ -1,0 +1,26 @@
+cmake_minimum_required(VERSION 2.8.3)
+
+get_filename_component(PACKAGE_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+message("Creating Package: ${PACKAGE_NAME}")
+
+project(${PACKAGE_NAME})  ## this package name is the name of the directory this cmake file is in
+
+find_package(catkin REQUIRED COMPONENTS message_generation std_msgs)
+
+FILE(GLOB rosMsgFiles RELATIVE "${${PROJECT_NAME}_SOURCE_DIR}/msg"
+    "${${PROJECT_NAME}_SOURCE_DIR}/msg/*.msg")
+
+FOREACH(rosMsg ${rosMsgFiles})
+    MESSAGE( STATUS "Processing message file: ${rosMsg}" )
+    add_message_files( FILES ${rosMsg})
+ENDFOREACH(rosMsg)
+
+add_message_files(
+  DIRECTORY msg
+  FILES
+  ${rosMsg}
+  )
+
+generate_messages(DEPENDENCIES std_msgs)
+
+catkin_package(CATKIN_DEPENDS message_runtime std_msgs)

--- a/hydrographic_core_msgs/README.md
+++ b/hydrographic_core_msgs/README.md
@@ -1,0 +1,5 @@
+# environmental_msgs
+
+Messages for processed quantitative data from common environmental sensors 
+e.g., temperature, turbidity, or dissolved oxygen.  These are "simple" 
+messages that publish the measured quantity in a common unit or metric.

--- a/hydrographic_core_msgs/README.md
+++ b/hydrographic_core_msgs/README.md
@@ -1,5 +1,3 @@
-# environmental_msgs
+# hydrographic_core_messages
 
-Messages for processed quantitative data from common environmental sensors 
-e.g., temperature, turbidity, or dissolved oxygen.  These are "simple" 
-messages that publish the measured quantity in a common unit or metric.
+Messages that are common to many types of hydrographic sensors or messages used as building blocks for messages in other packages.

--- a/hydrographic_core_msgs/msg/RawBinaryStamped.msg
+++ b/hydrographic_core_msgs/msg/RawBinaryStamped.msg
@@ -1,0 +1,2 @@
+std_msgs/Header header
+uint8[] data

--- a/hydrographic_core_msgs/msg/RawBinaryStamped.msg
+++ b/hydrographic_core_msgs/msg/RawBinaryStamped.msg
@@ -1,2 +1,8 @@
+# message to contain raw binary data from a sensor.
+
+# this message should be timestamped at the receive time of the first byte of the message.
+
+# the frame_id should be that of the sensor which sent the message
+
 std_msgs/Header header
 uint8[] data

--- a/hydrographic_core_msgs/msg/RawTextStamped.msg
+++ b/hydrographic_core_msgs/msg/RawTextStamped.msg
@@ -1,0 +1,2 @@
+std_msgs/Header header
+string data

--- a/hydrographic_core_msgs/msg/RawTextStamped.msg
+++ b/hydrographic_core_msgs/msg/RawTextStamped.msg
@@ -1,2 +1,8 @@
+# message to contain raw ASCII data from a sensor.
+
+# this message should be timestamped at the receive time of the first character of the message.
+
+# the frame_id should be that of the sensor which sent the message
+
 std_msgs/Header header
 string data

--- a/hydrographic_core_msgs/package.xml
+++ b/hydrographic_core_msgs/package.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>hydrographic_core_msgs</name>
+  <version>0.0.0</version>
+  <description>The environmental_smgs package, contains messages common to other hydrograhic_msgs
+  packages.  This may include core messages used by other message types or messages published directly
+  by typical sensor drivers (e.g. RawDataStamped).
+  </description>
+
+  <maintainer email="lindzey@uw.edu">Laura Lindzey</maintainer>
+
+  <license>BSD</license>
+
+  <author email="kris@seaward.science">Kristopher Krasnosky</author>
+  <author email="lindzey@uw.edu">Laura Lindzey</author>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <build_depend>message_generation</build_depend>
+  <build_depend>std_msgs</build_depend>
+
+  <build_export_depend>std_msgs</build_export_depend>
+
+   <exec_depend>message_runtime</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+
+</package>

--- a/hydrographic_core_msgs/package.xml
+++ b/hydrographic_core_msgs/package.xml
@@ -2,7 +2,7 @@
 <package format="2">
   <name>hydrographic_core_msgs</name>
   <version>0.0.0</version>
-  <description>The environmental_smgs package, contains messages common to other hydrograhic_msgs
+  <description>The environmental_msgs package contains messages common to other hydrographic_msgs
   packages.  This may include core messages used by other message types or messages published directly
   by typical sensor drivers (e.g. RawDataStamped).
   </description>


### PR DESCRIPTION
I have added a package designed to contain messages common to many types of hydrographic sensors.  I suggest this package also be used for messages that will be included by other message types in the hdrographic_msgs package.  

Two new message types have been included which represent raw data, either ASCII or binary.  The messages include a ROS header message that should be stamped with the receive time of the first character/byte.

-Kris