### PR TITLE
Rename num_beams to beam_count.

### DIFF
--- a/acoustic_msgs/msg/SonarImageData.msg
+++ b/acoustic_msgs/msg/SonarImageData.msg
@@ -14,7 +14,7 @@ uint32  DTYPE_FLOAT64 = 9
 uint32  dtype
 
 # the number of beams associated with the image
-uint32 num_beams
+uint32 beam_count
 
 # The actualy pixel data in row-major (beam_index major) format
 uint8[] data


### PR DESCRIPTION
This eliminates an abbreviation as well as a plural form in a field that could be one.