### PR TITLE
Add migration rule from v0.0.1 to 28ec6a7

### DIFF
--- a/acoustic_msgs/bmr/projected_sonar_image.bmr
+++ b/acoustic_msgs/bmr/projected_sonar_image.bmr
@@ -1,0 +1,253 @@
+class update_acoustic_msgs_SonarImage_62647765b51de3c2787ea163fd007d52(MessageUpdateRule):
+    old_type = "acoustic_msgs/SonarImage"
+    old_full_text = """
+# A single scan from an imaging sonar
+#
+# Imaging sonars produce an array of sonar beams radiating from a
+# common center.
+#
+# Data in this message must be in a North-East-Down (NED) coordinate frame.
+# In the most common configuration where the sonar produces a fan-shaped
+# array of beams, the central axis of each beam lies on the X-Y axis, with
+# each beam having an azimuth (rotation around the Z-axis) specified
+# in the vector "azimuth_angles".  Zero azimuth is typically "straight
+# ahead" from the physical sensor, and azimuth angles follow the NED
+# convention, with angles increasing to starboard.   Azimuth angles do
+# not need to be evenly spaced.
+#
+# Elevation is defined as rotation around the +Y axis, with negative
+# elevations "pitched down" and positive elevations "pitched up".
+# For the majority of sonars, all beams are centered in elevation on the
+# X-Y plane, such that all have an elevation of 0.  In this case
+# "elevation_angles" can be left empty.  If the elevation
+# differs on a beam-by-beam basis, values can be provided in the
+# "elevation_angles" field, however in that case "elevations_angles"
+# must be the same length as "azimuth_angles" -- equal to the number of
+# beams.
+#
+# For each beam, the sonar collects a sequence of acoustic returns
+# which are quantized into a fixed number of range bins by the sensor.
+# Radial distance from the sensor to the center of each range bin is reported
+# in the "ranges" vector.  Depending on the sensor's minimum range,
+# the "ranges" vector may start at a non-zero distance, and range bins need not
+# be equally spaced.   The speed of sound used by the sensor to calculate
+# the ranges, if known, can be included in the field "sound_speed"
+#
+# The measured acoustic return is stored for each range bin, for each
+# azimuthal beam, in the "intensities[]" array, as an azimuth-major array.
+# That is, the array contains returns for every range in sequence for the
+# first azimuth value, then the returns for every range for the second azimuth
+# value, and so on.   The interpretation or units for the intensities
+# will vary by sensor manufacturer.
+
+# The header timestamp gives the best estimate of the time for which the data
+# is valid. The exact relationship between timestamp and the sonar's data
+# acquisition cycle is determined by the sonar driver.
+Header header
+
+# Center frequency of sonar in Hz
+# Set to 0 if unavailable/unknown
+float32 frequency
+
+# Speed of sound (m/s) used to calculate ranges;
+# Set to 0 if unavailable/unknown
+float32 sound_speed
+
+# Beam width (as defined by the vendor) of a single sonar beam in the
+# azimuth direction, in radians
+float32 azimuth_beamwidth
+
+# Beam width (as defined by the vendor) of a single sonar beam in the
+# elevation direction, in radians
+float32 elevation_beamwidth
+
+# Azimuth for each beam, in radians.
+float32[] azimuth_angles
+
+# Elevation for each beam, in radians.
+# This vector can be left empty if all beams have an elevation
+# of 0.   If set, it must be the same length as azimuth_angles.
+float32[] elevation_angles
+
+# Center of each range bin in meters.
+# Rranges may not be equally spaced, and may not necessarily start
+# at zero range.
+float32[] ranges
+
+# True if data is big endian.
+bool      is_bigendian
+
+# Size of each datum (in bytes)
+uint8     data_size
+
+# intensity data [in device-specific units].
+#
+# Intensities is a dense data array, analogous to an image, with:
+#
+# len(intensities) =
+#           len(ranges)
+#         * len(azimuth_angles)
+#         * data_size
+#
+# Intensities are stored in *azimuth-major* order.
+uint8[]   intensities
+
+================================================================================
+MSG: std_msgs/Header
+# Standard metadata for higher-level stamped data types.
+# This is generally used to communicate timestamped data
+# in a particular coordinate frame.
+#
+# sequence ID: consecutively increasing ID
+uint32 seq
+#Two-integer timestamp that is expressed as:
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')
+# time-handling sugar is provided by the client library
+time stamp
+#Frame this data is associated with
+string frame_id
+"""
+
+    new_type = "acoustic_msgs/ProjectedSonarImage"
+    new_full_text = """
+# Single scan from an imaging sonar
+#
+# The X-axis is centered in the plane of the fan ("forward"), with Z down,
+# in order to be consistent with the NED convention.
+#
+# For sonars with a 1D array, the beams lie on the X-Y plane, and
+# and each beam has an azimuth (rotation about Z) value.  Zero azimuth
+# is in the direction of the X-axis, typically "straight out" from the sonar.
+# Elevation is the orthogonal direction (rotation about Y),
+# often termed the "vertical aperture"
+
+# The meaning of the header timestamp relative to the sonar's data
+# acquisition cycle is defined by the sonar driver. It is taken to be
+# a best estimate of the time when the sonar data is valid, which will
+# the timing information available from the sonar hardware.
+std_msgs/Header header
+
+PingInfo ping_info
+
+geometry_msgs/Vector3[] beam_directions
+
+# Center of each range bin in meters. Note this these may not be equally
+# spaced, and do not necessarily start at zero range.
+float32[] ranges
+
+SonarImageData image
+
+================================================================================
+MSG: std_msgs/Header
+# Standard metadata for higher-level stamped data types.
+# This is generally used to communicate timestamped data
+# in a particular coordinate frame.
+#
+# sequence ID: consecutively increasing ID
+uint32 seq
+#Two-integer timestamp that is expressed as:
+# * stamp.sec: seconds (stamp_secs) since epoch (in Python the variable is called 'secs')
+# * stamp.nsec: nanoseconds since stamp_secs (in Python the variable is called 'nsecs')
+# time-handling sugar is provided by the client library
+time stamp
+#Frame this data is associated with
+string frame_id
+
+================================================================================
+MSG: acoustic_msgs/PingInfo
+# Center frequency of sonar in Hz
+# Set to 0 if unavailable
+float32 frequency
+
+# Speed of sound (m/s) used to calculate ranges;
+# Set to 0 if unavailable
+float32 sound_speed
+
+# Sonar reported -3db beamwidths
+# May be empty if not reported
+# reported in radians
+float32[] tx_beamwidths
+float32[] rx_beamwidths
+
+================================================================================
+MSG: geometry_msgs/Vector3
+# This represents a vector in free space.
+# It is only meant to represent a direction. Therefore, it does not
+# make sense to apply a translation to it (e.g., when applying a
+# generic rigid transformation to a Vector3, tf2 will only apply the
+# rotation). If you want your data to be translatable too, use the
+# geometry_msgs/Point message instead.
+
+float64 x
+float64 y
+float64 z
+================================================================================
+MSG: acoustic_msgs/SonarImageData
+bool    is_bigendian
+
+uint32  DTYPE_UINT8 = 0
+uint32  DTYPE_INT8 = 1
+uint32  DTYPE_UINT16 = 2
+uint32  DTYPE_INT16 = 3
+uint32  DTYPE_UINT32 = 4
+uint32  DTYPE_INT32 = 5
+uint32  DTYPE_UINT64 = 6
+uint32  DTYPE_INT64 = 7
+uint32  DTYPE_FLOAT32 = 8
+uint32  DTYPE_FLOAT64 = 9
+
+uint32  dtype
+
+# the number of beams associated with the image
+uint32 beam_count
+
+# The actualy pixel data in row-major (beam_index major) format
+uint8[] data
+"""
+
+    order = 0
+    migrated_types = [
+        ("Header","Header"),]
+
+    valid = True
+
+    def update(self, old_msg, new_msg):
+        import numpy as np
+        self.migrate(old_msg.header, new_msg.header)
+
+        num_beams = len(old_msg.azimuth_angles)
+
+        new_msg.ping_info = self.get_new_class('acoustic_msgs/PingInfo')()
+        new_msg.ping_info.frequency = old_msg.frequency
+        new_msg.ping_info.sound_speed = old_msg.sound_speed
+        new_msg.ping_info.tx_beamwidths = num_beams * [old_msg.elevation_beamwidth]
+        new_msg.ping_info.rx_beamwidths = num_beams * [old_msg.azimuth_beamwidth]
+
+        Vector3 = self.get_new_class('geometry_msgs/Vector3')
+
+        # The old Oculus driver would leave this array empty to imply an array of zeros.
+        if len(old_msg.elevation_angles) == 0:
+            new_msg.beam_directions = [
+                Vector3(0.0, -1*np.sin(az), np.cos(az))
+                for az in old_msg.azimuth_angles]
+        else:
+            new_msg.beam_directions = [
+                Vector3(np.sin(el), -1*np.cos(el)*np.sin(az), np.cos(el)*np.cos(az))
+                for el, az in zip(old_msg.elevation_angles, old_msg.azimuth_angles)]
+
+        new_msg.ranges = old_msg.ranges
+
+        new_msg.image = self.get_new_class('acoustic_msgs/SonarImageData')()
+        new_msg.image.is_bigendian = old_msg.is_bigendian
+        if old_msg.data_size == 1:
+            new_msg.image.dtype = new_msg.image.DTYPE_UINT8
+        elif old_msg.data_size == 2:
+            new_msg.image.dtype = new_msg.image.DTYPE_UINT16
+        elif old_msg.data_size == 4:
+            new_msg.image.dtype = new_msg.image.DTYPE_UINT32
+        else:
+            raise Exception("Unexpected data_size in SonarImage: {}".format(old_msg.data_size))
+        new_msg.image.beam_count = len(new_msg.beam_directions)
+
+        new_msg.image.data = old_msg.intensities

--- a/acoustic_msgs/package.xml
+++ b/acoustic_msgs/package.xml
@@ -48,4 +48,10 @@
   <exec_depend>message_runtime</exec_depend>
   <exec_depend>std_msgs</exec_depend>
 
+  <depend>rosbag_migration_rule</depend>
+
+  <export>
+    <rosbag_migration_rule rule_file="bmr/projected_sonar_image.bmr"/>
+  </export>
+
 </package>


### PR DESCRIPTION
Hi @CaptKrasno & @rolker -- we're finally getting around to migrating all of our imaging sonar code to use the new message definitions from this summer.

Since we already had a decent amount of experimental data in the old format, I created a bag migration rule. Do you think it makes sense to add it to the repo?